### PR TITLE
This works well, still need norm cleanup

### DIFF
--- a/libft/openfd.c
+++ b/libft/openfd.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   openfd.c                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: ekosnick <ekosnick@student.42.fr>          +#+  +:+       +#+        */
+/*   By: ekosnick <ekosnick@student.42.f>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/27 09:56:37 by ekosnick          #+#    #+#             */
-/*   Updated: 2025/06/29 16:10:02 by ekosnick         ###   ########.fr       */
+/*   Updated: 2025/07/02 10:23:05 by ekosnick         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,3 +24,18 @@ int	openfd(char *fd, int in_out)
 	else
 		return (-1);
 }
+
+// int openfd(char *filename, int mode)
+// {
+// 	int fd;
+
+// 	if (mode == 0)
+// 		fd = open(filename, O_RDONLY);
+// 	else if (mode == 1)
+// 		fd = open(filename, O_CREAT | O_WRONLY | O_TRUNC, 0644);
+// 	else
+// 		fd = open(filename, O_CREAT | O_WRONLY | O_APPEND, 0644);
+// 	if (fd < 0)
+// 		perror("open failed");
+// 	return (fd);
+// }

--- a/pipex.h
+++ b/pipex.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   pipex.h                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: ekosnick <ekosnick@student.42.fr>          +#+  +:+       +#+        */
+/*   By: ekosnick <ekosnick@student.42.f>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/30 12:11:15 by ekosnick          #+#    #+#             */
-/*   Updated: 2025/06/29 13:23:51 by ekosnick         ###   ########.fr       */
+/*   Updated: 2025/07/02 13:17:19 by ekosnick         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,10 +26,19 @@
 # include <limits.h>   /* PATH_MAX (recommended for full_path buffer) */
 # include "libft/libft.h"
 
+typedef struct s_pip
+{
+	int	pid1;
+	int	pid2;
+	int	fdin;
+	int	fdout;
+}	t_pip;
+
 /*pipex_utils*/
 char	*cmd_path(int i, char **path_split, char *cmd);
 char	*pathfinder(char *cmd, char **env);
 void	laypipe(char *cmd_full, char **cmd_args, char **env);
+void	exec_cmd(int saved_cmd, char *av, char **env);
 void	here_doc_child_writer(char *delim, int fd);
 
 #endif

--- a/pipex1.c
+++ b/pipex1.c
@@ -1,0 +1,239 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   pipex.c                                            :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: ekosnick <ekosnick@student.42.f>           +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/05/30 12:17:10 by ekosnick          #+#    #+#             */
+/*   Updated: 2025/07/02 13:20:24 by ekosnick         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "pipex.h"
+
+// void	dig_ditch(char *av, char **env)
+// {
+// 	char	*cmd_full;
+// 	char	**cmd_args;
+
+// 	cmd_args = ft_split(av, ' ');
+// 	if (!cmd_args)
+// 	{
+// 		perror("split failed");
+// 		return ;
+// 	}
+// 	if (!cmd_args[0] || !cmd_args[0][0])
+// 	{
+// 		printf("Empty command\n");
+// 		ft_free_split(cmd_args);
+// 		return ;
+// 	}
+// 	cmd_full = pathfinder(cmd_args[0], env);
+// 	if (!cmd_full)
+// 	{
+// 		printf("Command '%s' not found\n", cmd_args[0]);
+// 		ft_free_split(cmd_args);
+// 		return ;
+// 	}
+// 	laypipe(cmd_full, cmd_args, env);
+// 	free(cmd_full);
+// 	ft_free_split(cmd_args);
+// }
+
+// void	last_cmd(int ac, char **av, char **env)
+// {
+// 	char	*cmd_full;
+// 	char	**cmd_args;
+
+// 	cmd_args = ft_split(av[ac - 2], ' ');
+// 	if (!cmd_args)
+// 	{
+// 		printf("split failed\n");
+// 		exit(127);
+// 	}
+// 	if (!cmd_args[0] || !cmd_args[0][0])
+// 	{
+// 		printf("Empty command\n");
+// 		ft_free_split(cmd_args);
+// 		exit(127);
+// 	}
+// 	cmd_full = pathfinder(cmd_args[0], env);
+// 	if (!cmd_full)
+// 	{
+// 		printf("Command '%s' not found\n", cmd_args[0]);
+// 		ft_free_split(cmd_args);
+// 		exit(127);
+// 	}
+// 	execve(cmd_full, cmd_args, env);
+// 	perror("execve failed");
+// 	free(cmd_full);
+// 	ft_free_split(cmd_args);
+// 	exit(1);
+// }
+
+// int	main(int ac, char **av, char **env)
+// {
+// 	int		fdin;
+// 	int		fdout;
+// 	int		i;
+
+// 	if (ac == 5)
+// 	{
+// 		if (access(av[1], F_OK) != 0)
+// 		{
+// 			perror(av[1]);
+// 			return (1);
+// 		}
+// 		fdin = openfd(av[1], 0);
+// 		dup2(fdin, 0);
+// 		i = 2;
+// 		printf("Before digditch loop ->	i = %i\n", i);
+// 		while (i < ac -2)
+// 			dig_ditch(av[i++], env);
+// 		printf("After digditch loop ->	i = %i\n", i);
+// 		fdout = openfd(av[ac - 1], 1);
+// 		printf("openfd fdout = %i\n", fdout);
+// 		dup2(fdout, 1);
+// 		last_cmd(ac, av, env);
+// 		printf("After the last command\n");
+// 		return (0);
+// 	}
+// 	else
+// 		ft_printf("./pipex infile cmd1 cmd2 outfile\n");
+// 	return (1);
+// }
+
+void	child1(int pid1, int fdin, int *pipefd, char **av, char **env)
+{
+	int saved_cmd;
+
+	if (pid1 == 0)
+	{
+		if (dup2(fdin, STDIN_FILENO) == -1)
+		{
+			ft_printf("Input file:'%s' not found\n", av[1]);
+			exit(1);
+		}
+		saved_cmd = dup(STDOUT_FILENO);
+		dup2(pipefd[1], STDOUT_FILENO);
+		close(pipefd[0]);
+		close(pipefd[1]);
+		exec_cmd(saved_cmd, av[2], env);
+	}
+}
+
+void	child2(int pid2, int fdout, int *pipefd, char **av, char **env)
+{
+	int saved_cmd;
+	
+	if (pid2 == 0)
+	{
+		saved_cmd = dup(STDOUT_FILENO);
+		dup2(pipefd[0], STDIN_FILENO);
+		if (dup2(fdout, STDOUT_FILENO) == -1)
+		{
+			ft_printf("Outfile '%s' failed\n", av[4]);
+			exit(1);
+		}
+		close(pipefd[0]);
+		close(pipefd[1]);
+		exec_cmd(saved_cmd, av[3], env);
+	}
+}
+
+// void	child2(int pid2, int fdout, int *pipefd, char **av, char **env)
+// {
+// 	if (pid2 == 0)
+// 	{
+// 		dup2(pipefd[0], STDIN_FILENO);
+// 		dup2(fdout, STDOUT_FILENO);
+// 		close(pipefd[0]);
+// 		close(pipefd[1]);
+// 		exec_cmd(av[3], env);
+// 	}
+// }
+
+void	parent(int pid1, int pid2, int *pipefd)
+{
+	close(pipefd[0]);
+	close(pipefd[1]);
+	waitpid(pid1, NULL, 0);
+	waitpid(pid2, NULL, 0);	
+}
+
+int	start_pipex(int ac, char **av, char **env)
+{
+	int		fdin;
+	int		fdout;
+	int		pipefd[2];
+	int		pid1;
+	int		pid2;
+
+	if (access(av[1], F_OK) != 0)
+	{
+		perror(av[1]);
+		return (1);
+	}
+	pipe(pipefd);
+	fdin = openfd(av[1], 0);
+	fdout = openfd(av[ac - 1], 1);
+	if (fdin < 0 || fdout < 0)
+	{
+		perror("open");
+		return (1);
+	}
+	pid1 = fork();
+	child1(pid1, fdin, pipefd, av, env);
+	pid2 = fork();
+	child2(pid2, fdout, pipefd, av, env);
+	parent(pid1, pid2, pipefd);
+	return (0);
+}
+
+int	main(int ac, char **av, char **env)
+{
+	if (ac != 5)
+	{
+	ft_printf("./pipex infile cmd1 cmd2 outfile\n");
+	return (1);	
+	}
+	start_pipex(ac, av, env);
+	return (0);
+}
+
+
+// int	main(int ac, char **av, char **env)
+// {
+// 	int		fdin;
+// 	int		fdout;
+// 	int		pipefd[2];
+// 	int		pid1;
+// 	int		pid2;
+
+// 	if (ac == 5)
+// 	{
+// 		if (access(av[1], F_OK) != 0)
+// 		{
+// 			perror(av[1]);
+// 			return (1);
+// 		}
+// 		pipe(pipefd);
+// 		fdin = openfd(av[1], 0);
+// 		fdout = openfd(av[ac - 1], 1);
+// 		if (fdin < 0 || fdout < 0)
+// 		{
+// 			perror("open");
+// 			return (1);
+// 		}
+// 		pid1 = fork();
+// 		child1(pid1, fdin, pipefd, av, env);
+// 		pid2 = fork();
+// 		child2(pid2, fdout, pipefd, av, env);
+// 		parent(pid1, pid2, pipefd);
+// 		return (0);
+// 	}
+// 	else
+// 		ft_printf("./pipex infile cmd1 cmd2 outfile\n");
+// 	return (1);
+// }

--- a/pipex_utils.c
+++ b/pipex_utils.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   pipex_utils.c                                      :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: ekosnick <ekosnick@student.42.fr>          +#+  +:+       +#+        */
+/*   By: ekosnick <ekosnick@student.42.f>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/12 12:20:49 by ekosnick          #+#    #+#             */
-/*   Updated: 2025/06/29 10:53:12 by ekosnick         ###   ########.fr       */
+/*   Updated: 2025/07/02 12:29:20 by ekosnick         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -68,6 +68,28 @@ char	*pathfinder(char *cmd, char **env)
 	return (cmd_pt);
 }
 
+void	exec_cmd(int saved_cmd, char *av, char **env)
+{
+	char **cmd_args;
+	char *cmd_full;
+
+	cmd_args = ft_split(av, ' ');
+	cmd_full = pathfinder(cmd_args[0], env);
+	if (!cmd_full)
+	{
+		dup2(saved_cmd, STDOUT_FILENO);
+		ft_printf("Command '%s' not found\n", cmd_args[0]);
+		ft_free_split(cmd_args);
+		close(saved_cmd);
+		exit(127);
+	}
+	execve(cmd_full, cmd_args, env);
+	perror("execve");
+	free(cmd_full);
+	ft_free_split(cmd_args);
+	exit(1);
+}
+
 void	laypipe(char *cmd_full, char **cmd_args, char **env)
 {
 	int		fd[2];
@@ -90,3 +112,26 @@ void	laypipe(char *cmd_full, char **cmd_args, char **env)
 		exit(EXIT_FAILURE);
 	}
 }
+
+// void	laypipe2(char *cmd_full, char **cmd_args, char **env)
+// {
+// 	int		fd[2];
+// 	int		pid;
+
+// 	pipe(fd);
+// 	pid = fork();
+// 	if (pid > 0)
+// 	{
+// 		close(fd[1]);
+// 		dup2(fd[0], 0);
+// 		waitpid(pid, NULL, 0);
+// 	}
+// 	if (pid == 0)
+// 	{
+// 		close(fd[0]);
+// 		dup2(fd[1], 1);
+// 		execve(cmd_full, cmd_args, env);
+// 		perror("Child Error:");
+// 		exit(EXIT_FAILURE);
+// 	}
+// }


### PR DESCRIPTION
At some point the helper functions (e.g. digditch(), last_cmd() ... ) were turned to int instead of void as it was perceived to be better to track processes between function. However, this was the wrong decision, but illuminated some useful information on debugging. I was then able to go back to a later version and created the keeping-the-void branch and was able to update this into the working verion.